### PR TITLE
Utilize the guided scenarios page in favor of the Windows 365 pane

### DIFF
--- a/Windows365/enterprise/windows-365-boot-guide.md
+++ b/Windows365/enterprise/windows-365-boot-guide.md
@@ -54,8 +54,8 @@ You can complete the guided scenario before there are any devices in the group. 
 ## Step 1 - Introduction
 
 1. Sign in to the [Microsoft Intune admin center](https://go.microsoft.com/fwlink/?linkid=2109431) as a user with the Intune Service Administrator role.
-2. Select **Devices** > **Windows 365** (under **Overview**) > **Windows 365 Boot** (under Windows 365 guides).
-3. On the **Introduction** page, select **Next: Basics**.
+2. Select **Troubleshooting + support** > **Guided scenarios (preview)**. Start the Windows 365 Boot guided scenario.
+4. On the **Introduction** page, select **Next: Basics**.
 
 ## Step 2 - Basics
 


### PR DESCRIPTION
Although the focus is for Windows 365 Enterprise, this page is more accessible and allows users that subscribe to Windows 365 Business to follow the guided boot scenario.

A redirect link can then be established in the Windows 365 Business page.